### PR TITLE
[Build] Update dockerfile to use compatible version of Bundler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,3 @@ matrix:
   fast_finish: true
 install: ci/unit/docker-setup.sh
 script: ci/unit/docker-run.sh
-before_install: gem install bundler -v '< 2'

--- a/ci/unit/Dockerfile
+++ b/ci/unit/Dockerfile
@@ -6,7 +6,7 @@ RUN cp /usr/share/logstash/logstash-core/versions-gem-copy.yml /usr/share/logsta
 ENV PATH="${PATH}:/usr/share/logstash/vendor/jruby/bin"
 ENV LOGSTASH_SOURCE=1
 ENV JARS_SKIP="true"
-RUN gem install bundler
+RUN gem install bundler -v '< 2'
 WORKDIR /usr/share/plugins/this
 RUN bundle install
 COPY --chown=logstash:logstash . /usr/share/plugins/this


### PR DESCRIPTION
Bundler 2.0 introduced requirements that are incompatible with the version of Ruby shipped with Logstash 5.6. This commit installs a pre 2.0 version of Bundler. It also removes an irrelevant step from the travis yml