### PR TITLE
[DOC] Add GET and SET examples and fix formatting

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -23,18 +23,20 @@ include::{include_path}/plugin_header.asciidoc[]
 The Memcached filter provides integration with external data in Memcached.
 
 It currently provides the following facilities:
- - `get`: get values for one or more memcached keys and inject them into the event at the provided paths
- - `set`: set values from the event to the corresponding memcached keys
+
+ * `get`: get values for one or more memcached keys and inject them into the event at the
+ provided paths
  
-==== EXAMPLES
+ * `set`: set values from the event to the corresponding memcached keys
  
-The this plugin enables key/value lookup enrichment against a Memcached object
-caching system. It supports both read (GET) and write (SET) operations. It is a
-notable addition for security analytics use cases. For example, you can use this
-plugin to query for a value, and set it if not found.
-+
-GET example:
-+
+==== Examples
+ 
+This plugin enables key/value lookup enrichment against a Memcached object
+caching system. You can use this plugin to query for a value, and set it if not
+found.
+
+===== GET example
+
 [source,txt]
 -----
 memcached {
@@ -47,9 +49,9 @@ memcached {
     id => "memcached-get"
   }
 -----
-+
-SET example:
-+
+
+===== SET example
+
 [source,txt]
 -----
 memcached {
@@ -103,7 +105,7 @@ If more than one host is specified, requests will be distributed to the given ho
 
 If specified, prefix all memcached keys with the given string followed by a colon (`:`); this is useful if all keys being used by this plugin share a common prefix.
 
-EXAMPLE:
+Example:
 
 In the following configuration, we would GET `fruit:banana` and `fruit:apple` from memcached:
 ----

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -25,7 +25,43 @@ The Memcached filter provides integration with external data in Memcached.
 It currently provides the following facilities:
  - `get`: get values for one or more memcached keys and inject them into the event at the provided paths
  - `set`: set values from the event to the corresponding memcached keys
-
+ 
+==== EXAMPLES
+ 
+The this plugin enables key/value lookup enrichment against a Memcached object
+caching system. It supports both read (GET) and write (SET) operations. It is a
+notable addition for security analytics use cases. For example, you can use this
+plugin to query for a value, and set it if not found.
++
+GET example:
++
+[source,txt]
+-----
+memcached {
+    hosts => ["localhost"]
+    namespace => "convert_mm"
+    get => {
+      "%{millimeters}" => "[inches]"
+    }
+    add_tag => ["from_cache"]
+    id => "memcached-get"
+  }
+-----
++
+SET example:
++
+[source,txt]
+-----
+memcached {
+    hosts => ["localhost"]
+    namespace => "convert_mm"
+    set => {
+      "[inches]" => "%{millimeters}"
+    }
+    id => "memcached-set"
+  }
+-----
+ 
 [id="plugins-{type}s-{plugin}-options"]
 ==== Memcached Filter Configuration Options
 


### PR DESCRIPTION
Add examples for GET and SET to the intro in addition to the ones already in the GET/SET option descriptions.  
Fix asciidoc formatting