### PR TITLE
Add network and connection exception handling 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.1.0
+ - Added better exception handling [#25](https://github.com/logstash-plugins/logstash-filter-memcached/pull/25)
+
 ## 1.0.2
  - Fixed issue with ttl not being set [#13](https://github.com/logstash-plugins/logstash-filter-memcached/pull/13)
 

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -2,7 +2,8 @@ The following is a list of people who have contributed ideas, code, bug
 reports, or in general have helped logstash along its way.
 
 Contributors:
-* Ry Biesemeyer - ry.biesemeyer@elastic.co
+* Ry Biesemeyer (yaauie)
+* Colin Surprenant (colinsurprenant)
 
 Note: If you've sent us patches, bug reports, or otherwise contributed to
 Logstash, and you aren't on the list above and want to be, please let us know

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -76,6 +76,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-namespace>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-get>> |<<hash,hash>>|No
 | <<plugins-{type}s-{plugin}-set>> |<<hash,hash>>|No
+| <<plugins-{type}s-{plugin}-tag_on_failure>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-ttl>> |<<number,number>>|No
 |=======================================================================
 
@@ -163,6 +164,16 @@ filter {
   }
 }
 ----
+
+[id="plugins-{type}s-{plugin}-tag_on_failure"]
+===== `tag_on_failure`
+
+  * Value type is <<string,string>>
+  * The default value for this setting is `_memcached_failure`.
+
+When a memcached operation causes a runtime exception to be thrown within the plugin,
+the operation is safely aborted without crashing the plugin, and the event is
+tagged with the provided value.
 
 [id="plugins-{type}s-{plugin}-ttl"]
 ===== `ttl`

--- a/lib/logstash/filters/memcached.rb
+++ b/lib/logstash/filters/memcached.rb
@@ -3,7 +3,6 @@ require "logstash/filters/base"
 require "logstash/namespace"
 require 'dalli'
 
-
 # This filter provides facilities to interact with Memcached.
 class LogStash::Filters::Memcached < LogStash::Filters::Base
 

--- a/logstash-filter-memcached.gemspec
+++ b/logstash-filter-memcached.gemspec
@@ -3,9 +3,9 @@ Gem::Specification.new do |s|
   s.version       = '1.0.2'
   s.licenses      = ['Apache-2.0']
   s.summary       = 'A Logstash filter plugin for interacting with memcached'
-  s.homepage      = 'https://github.com/yaauie/logstash-filter-memcached'
-  s.authors       = ['Ry Biesemeyer']
-  s.email         = 'ry.biesemeyer@elastic.co'
+  s.authors       = ["Elastic"]
+  s.email         = 'info@elastic.co'
+  s.homepage      = "http://www.elastic.co/guide/en/logstash/current/index.html"
   s.require_paths = ['lib']
 
   # Files

--- a/logstash-filter-memcached.gemspec
+++ b/logstash-filter-memcached.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name          = 'logstash-filter-memcached'
-  s.version       = '1.0.2'
+  s.version       = '1.1.0'
   s.licenses      = ['Apache-2.0']
   s.summary       = 'A Logstash filter plugin for interacting with memcached'
   s.authors       = ["Elastic"]

--- a/spec/filters/memcached_spec.rb
+++ b/spec/filters/memcached_spec.rb
@@ -7,87 +7,150 @@ LogStash::Logging::Logger::configure_logging("TRACE")
 describe LogStash::Filters::Memcached do
   subject(:memcached_filter) { described_class.new(config) }
   let(:cache) { double('memcached') }
-  before(:each) do
-    allow(memcached_filter).to receive(:establish_connection).and_return(cache)
-    allow(memcached_filter).to receive(:close)
-    memcached_filter.register
+
+  describe "a well behaved memcached server" do
+    before(:each) do
+      allow(memcached_filter).to receive(:new_connection).and_return(cache)
+      allow(memcached_filter).to receive(:close)
+      memcached_filter.register
+    end
+
+    after(:each) do
+      memcached_filter.close
+    end
+
+    describe "#get" do
+      let(:event) { ::LogStash::Event.new(data) }
+      let(:config) do
+        {
+          "hosts" => ["localhost:11211"],
+          "get" => { "success/%{success}/answer" => "[ultimate][answer]" }
+        }
+      end
+      let(:data) { { "success" => "true" } }
+
+      it "retrieves data from memcache" do
+        expect(cache).to receive(:get_multi).with(["success/true/answer"]).and_return({"success/true/answer" => "42"})
+        expect(memcached_filter).to receive(:filter_matched)
+        memcached_filter.filter(event)
+        expect(event.get("ultimate")).to eq("answer" => "42")
+      end
+
+      context 'when memcached does not hold the value' do
+        before do
+          expect(cache).to receive(:get_multi).with(["success/true/answer"]).and_return({"success/true/answer" => nil})
+        end
+
+        it 'does not invoke `filter_matched`' do
+          expect(memcached_filter).to_not receive(:filter_matched)
+          memcached_filter.filter(event)
+        end
+
+        it 'does not populate the value' do
+          memcached_filter.filter(event)
+          expect(event.include?("ultimate")).to be false
+        end
+      end
+    end
+
+    describe "#set" do
+      let(:event) { ::LogStash::Event.new(data) }
+      let(:config) do
+        {
+          "hosts" => ["localhost:11211"],
+          "set" => { "[answer]" => "success/%{success}/answer" },
+        }
+      end
+      before(:each) do
+        allow(cache).to receive(:multi) {|&b| b.call }
+        allow(cache).to receive(:set)
+      end
+
+      context 'when the event includes the value to set' do
+        let(:data) { { "answer" => "42", "success" => "true" } }
+
+        it "sets data on memcached" do
+          expect(cache).to receive(:set).with("success/true/answer", "42")
+          memcached_filter.filter(event)
+        end
+
+        it 'invokes `filter_matched`' do
+          expect(memcached_filter).to receive(:filter_matched)
+          memcached_filter.filter(event)
+        end
+      end
+
+      context 'when the event does not include the value being set' do
+        let(:data) { { "success" => "true" } }
+
+        it 'does not set data on memcached' do
+          expect(cache).to_not receive(:set)
+          memcached_filter.filter(event)
+        end
+
+        it 'does not invoke `filter_matched`' do
+          expect(memcached_filter).to_not receive(:filter_matched)
+          memcached_filter.filter(event)
+        end
+      end
+    end
   end
 
-  after(:each) do
-    memcached_filter.close
-  end
-
-  describe "#get" do
-    let(:event) { ::LogStash::Event.new(data) }
+  describe "a misbehaved memcached server" do
     let(:config) do
       {
         "hosts" => ["localhost:11211"],
-        "get" => { "success/%{success}/answer" => "[ultimate][answer]" }
-      }
-    end
-    let(:data) { { "success" => "true" } }
-
-    it "retrieves data from memcache" do
-      expect(cache).to receive(:get_multi).with(["success/true/answer"]).and_return({"success/true/answer" => "42"})
-      expect(memcached_filter).to receive(:filter_matched)
-      memcached_filter.filter(event)
-      expect(event.get("ultimate")).to eq("answer" => "42")
-    end
-
-    context 'when memcached does not hold the value' do
-      before do
-        expect(cache).to receive(:get_multi).with(["success/true/answer"]).and_return({"success/true/answer" => nil})
-      end
-
-      it 'does not invoke `filter_matched`' do
-        expect(memcached_filter).to_not receive(:filter_matched)
-        memcached_filter.filter(event)
-      end
-
-      it 'does not populate the value' do
-        memcached_filter.filter(event)
-        expect(event.include?("ultimate")).to be false
-      end
-    end
-  end
-
-  describe "#set" do
-    let(:event) { ::LogStash::Event.new(data) }
-    let(:config) do
-      {
-        "hosts" => ["localhost:11211"],
+        "get" => { "success/%{success}/answer" => "[ultimate][answer]" },
         "set" => { "[answer]" => "success/%{success}/answer" },
       }
     end
-    before(:each) do
-      allow(cache).to receive(:multi) {|&b| b.call }
-      allow(cache).to receive(:set)
+
+    context "#register" do
+      it "raises error upon new connection error" do
+        allow(memcached_filter).to receive(:new_connection).and_raise("some error")
+        expect{memcached_filter.register}.to raise_error(RuntimeError)
+      end
     end
 
-    context 'when the event includes the value to set' do
+    context "#get and #set" do
+      let(:event) { ::LogStash::Event.new(data) }
       let(:data) { { "answer" => "42", "success" => "true" } }
 
-      it "sets data on memcached" do
-        expect(cache).to receive(:set).with("success/true/answer", "42")
-        memcached_filter.filter(event)
+      before(:each) do
+        allow(memcached_filter).to receive(:new_connection).and_return(cache)
+        allow(cache).to receive(:close).and_raise("some error")
+
+        memcached_filter.register
       end
 
-      it 'invokes `filter_matched`' do
-        expect(memcached_filter).to receive(:filter_matched)
-        memcached_filter.filter(event)
-      end
-    end
-
-    context 'when the event does not include the value being set' do
-      let(:data) { { "success" => "true" } }
-
-      it 'does not set data on memcached' do
-        expect(cache).to_not receive(:set)
-        memcached_filter.filter(event)
+      after(:each) do
+        memcached_filter.close
       end
 
-      it 'does not invoke `filter_matched`' do
-        expect(memcached_filter).to_not receive(:filter_matched)
+      it "fails #get and tag" do
+        allow(cache).to receive(:multi) { |&b| b.call }
+        allow(cache).to receive(:set).with("success/true/answer", "42")
+        expect(cache).to receive(:get_multi).with(["success/true/answer"]).and_raise(Dalli::RingError.new("foo"))
+        expect(memcached_filter).not_to receive(:filter_matched)
+        memcached_filter.filter(event)
+        expect(event.get("tags")).to eq(["_memcached_failure"])
+      end
+
+      it "fails #set and tag" do
+        allow(cache).to receive(:get_multi).with(["success/true/answer"]).and_return({"success/true/answer" => "42"})
+        allow(cache).to receive(:multi) { |&b| b.call }
+        expect(cache).to receive(:set).with("success/true/answer", "42").and_raise(Dalli::RingError.new("foo"))
+        expect(memcached_filter).not_to receive(:filter_matched)
+        memcached_filter.filter(event)
+        expect(event.get("tags")).to eq(["_memcached_failure"])
+      end
+
+      it "reconnects after a failure" do
+        allow(memcached_filter).to receive(:do_get).and_raise(Dalli::RingError.new("foo"))
+        allow(memcached_filter).to receive(:do_set).and_raise(Dalli::RingError.new("foo"))
+
+        expect(memcached_filter).to receive(:new_connection).once.and_raise("foo")
+        memcached_filter.filter(event)
         memcached_filter.filter(event)
       end
     end


### PR DESCRIPTION
Fixes #23

- add network and connection exception handling in the `filter` method. An exception will tag event and close the connection. Upon next `filter` method call a reconnection will be attempted.
- add `tag_on_failure` option
- add related specs
- bump to v1.1.0